### PR TITLE
chore: rename the plugin to trivy-mcp

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            trivy-plugin-mcp-*.tar.gz
+            trivy-mcp-*.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@ policy
 fanal
 windows
 
-trivy-plugin-mcp-*
+trivy-mcp-*
 plugin.yaml.bak
 mcp

--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,28 @@
 SED=$(shell command -v gsed || command -v sed)
 PLATFORMS = linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64
-OUTPUTS = $(patsubst %,%/trivy-plugin-mcp,$(PLATFORMS))
+OUTPUTS = $(patsubst %,%/trivy-mcp,$(PLATFORMS))
 
 .PHONY: clean
 clean:
-	rm -rf trivy-plugin-mcp*
+	rm -rf trivy-mcp*
 
 .PHONY: build
 build: clean $(OUTPUTS)
 
-%/trivy-plugin-mcp:
+%/trivy-mcp:
 	@[ $$NEW_VERSION ] || ( echo "env 'NEW_VERSION' is not set"; exit 1 )
 	@echo "Building for $*..."
 	@mkdir -p $(dir $@); \
 	GOOS=$(word 1,$(subst /, ,$*)); \
 	GOARCH=$(word 2,$(subst /, ,$*)); \
-	CGO_ENABLED=0 GOOS=$$GOOS GOARCH=$$GOARCH go build -ldflags "-s -w -X github.com/aquasecurity/trivy-plugin-mcp/pkg/version.Version=$${NEW_VERSION}" -o mcp ./cmd/trivy-mcp/main.go; \
+	CGO_ENABLED=0 GOOS=$$GOOS GOARCH=$$GOARCH go build -ldflags "-s -w -X github.com/aquasecurity/trivy-mcp/pkg/version.Version=$${NEW_VERSION}" -o trivy-mcp ./cmd/trivy-mcp/main.go; \
 	if [ $$GOOS = "windows" ]; then \
-		mv mcp mcp.exe; \
-		tar -czf trivy-plugin-mcp-$$GOOS-$$GOARCH.tar.gz plugin.yaml mcp.exe LICENSE > /dev/null; \
-		rm mcp.exe; \
+		mv trivy-mcp trivy-mcp.exe; \
+		tar -czf trivy-mcp-$$GOOS-$$GOARCH.tar.gz plugin.yaml trivy-mcp.exe LICENSE > /dev/null; \
+		rm trivy-mcp.exe; \
 	else \
-		tar -czf trivy-plugin-mcp-$$GOOS-$$GOARCH.tar.gz plugin.yaml mcp LICENSE > /dev/null; \
-		rm mcp; \
+		tar -czf trivy-mcp-$$GOOS-$$GOARCH.tar.gz plugin.yaml trivy-mcp LICENSE > /dev/null; \
+		rm trivy-mcp; \
 	fi
 
 .PHONY: add-plugin-manifest

--- a/cmd/trivy-mcp/main.go
+++ b/cmd/trivy-mcp/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/aquasecurity/trivy-plugin-mcp/pkg/commands"
+	"github.com/aquasecurity/trivy-mcp/pkg/commands"
 	"github.com/aquasecurity/trivy/pkg/log"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/aquasecurity/trivy-plugin-mcp
+module github.com/aquasecurity/trivy-mcp
 
 go 1.24.2
 

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/viper"
 	"golang.org/x/xerrors"
 
-	"github.com/aquasecurity/trivy-plugin-mcp/pkg/flag"
+	"github.com/aquasecurity/trivy-mcp/pkg/flag"
 	trivyflag "github.com/aquasecurity/trivy/pkg/flag"
 	"github.com/aquasecurity/trivy/pkg/log"
 )

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -3,8 +3,8 @@ package commands
 import (
 	"context"
 
-	"github.com/aquasecurity/trivy-plugin-mcp/pkg/flag"
-	"github.com/aquasecurity/trivy-plugin-mcp/pkg/mcpserver"
+	"github.com/aquasecurity/trivy-mcp/pkg/flag"
+	"github.com/aquasecurity/trivy-mcp/pkg/mcpserver"
 	"github.com/aquasecurity/trivy/pkg/log"
 )
 

--- a/pkg/mcpserver/mcp.go
+++ b/pkg/mcpserver/mcp.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/aquasecurity/trivy-plugin-mcp/pkg/flag"
-	"github.com/aquasecurity/trivy-plugin-mcp/pkg/mcpserver/tools"
-	"github.com/aquasecurity/trivy-plugin-mcp/pkg/version"
+	"github.com/aquasecurity/trivy-mcp/pkg/flag"
+	"github.com/aquasecurity/trivy-mcp/pkg/mcpserver/tools"
+	"github.com/aquasecurity/trivy-mcp/pkg/version"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/mark3labs/mcp-go/server"
 )

--- a/pkg/mcpserver/tools/scan.go
+++ b/pkg/mcpserver/tools/scan.go
@@ -67,7 +67,7 @@ func (t *TrivyTools) scanWithTrivyHandler(ctx context.Context, request mcp.CallT
 	}
 
 	logger := log.WithPrefix(targetType)
-	tempFile := filepath.Join(os.TempDir(), "trivy-plugin-mcp-scan.results.json")
+	tempFile := filepath.Join(os.TempDir(), "trivy-mcp-scan.results.json")
 	args := []string{
 		targetType,
 		fmt.Sprintf("--scanners=%s", strings.Join(scanTypeStr, ",")),

--- a/pkg/mcpserver/tools/tool.go
+++ b/pkg/mcpserver/tools/tool.go
@@ -3,7 +3,7 @@ package tools
 import (
 	"context"
 
-	"github.com/aquasecurity/trivy-plugin-mcp/pkg/flag"
+	"github.com/aquasecurity/trivy-mcp/pkg/flag"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/mark3labs/mcp-go/mcp"
 )

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,6 +1,6 @@
 name: mcp
-repository: github.com/aquasecurity/trivy-plugin-mcp
-version: 0.0.3
+repository: github.com/aquasecurity/trivy-mcp
+version: 0.0.4
 summary: Starts an MCP server that knows how to work with Trivy
 description: |-
   A Trivy plugin that starts an MCP server that knows how to work with Trivy.
@@ -9,25 +9,25 @@ platforms:
     - selector:
         os: linux
         arch: amd64
-      uri: https://github.com/aquasecurity/trivy-plugin-mcp/releases/download/v0.0.3/trivy-plugin-mcp-linux-amd64.tar.gz
-      bin: ./mcp
+      uri: https://github.com/aquasecurity/trivy-mcp/releases/download/v0.0.4/trivy-mcp-linux-amd64.tar.gz
+      bin: ./trivy-mcp
     - selector:
         os: linux
         arch: arm64
-      uri: https://github.com/aquasecurity/trivy-plugin-mcp/releases/download/v0.0.3/trivy-plugin-mcp-linux-arm64.tar.gz
-      bin: ./mcp
+      uri: https://github.com/aquasecurity/trivy-mcp/releases/download/v0.0.4/trivy-mcp-linux-arm64.tar.gz
+      bin: ./trivy-mcpp
     - selector:
         os: darwin
         arch: amd64
-      uri: https://github.com/aquasecurity/trivy-plugin-mcp/releases/download/v0.0.3/trivy-plugin-mcp-darwin-amd64.tar.gz
-      bin: ./mcp
+      uri: https://github.com/aquasecurity/trivy-mcp/releases/download/v0.0.4/trivy-mcp-darwin-amd64.tar.gz
+      bin: ./trivy-mcp
     - selector:
         os: darwin
         arch: arm64
-      uri: https://github.com/aquasecurity/trivy-plugin-mcp/releases/download/v0.0.3/trivy-plugin-mcp-darwin-arm64.tar.gz
-      bin: ./mcp
+      uri: https://github.com/aquasecurity/trivy-mcp/releases/download/v0.0.4/trivy-mcp-darwin-arm64.tar.gz
+      bin: ./trivy-mcp
     - selector:
         os: windows
         arch: amd64
-      uri: https://github.com/aquasecurity/trivy-plugin-mcp/releases/download/v0.0.3/trivy-plugin-mcp-windows-amd64.tar.gz
-      bin: ./mcp
+      uri: https://github.com/aquasecurity/trivy-mcp/releases/download/v0.0.4/trivy-mcp-windows-amd64.tar.gz
+      bin: ./trivy-mcp


### PR DESCRIPTION
Rename the plugin so that it isn't just a plugin and can be treated as a
binary

Signed-off-by: Owen Rumney <owen.rumney@aquasec.com>
